### PR TITLE
add git-credential-1password

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -310,5 +310,14 @@
 		"url": "https://github.com/alfredapp/1password-workflow/",
 		"description": "Search and open 1Password items with Alfred",
 		"tags": ["alfred", "cli", "macos", "search"]
+	},
+	{
+		"category": "repo",
+		"id": "git-credential-1password",
+		"title": "1Password Git Credential Helper",
+		"author": "develerik",
+		"url": "https://github.com/develerik/git-credential-1password",
+		"description": "Credential helper to store git credentials inside 1Password",
+		"tags": ["cli", "git", "go"]
 	}
 ]


### PR DESCRIPTION
## Project name

git-credential-1password

#### Short description

git-credential-1password is a credential helper for git, which stores secrets inside 1Password.

#### Project category

- [x] Repository
- [ ] Article
- [ ] Video

#### Developer Tools used

- [x] CLI
- [ ] Connect Server
- [ ] CI/CD Integrations
- [ ] SSH Agent
- [ ] Events Reporting API
- [ ] Passage or passwordless
- [ ] Something else...

#### URL

https://github.com/develerik/git-credential-1password

#### Author

Erik Bender <erik.bender@develerik.dev>

#### Can we contact you?

We'd love to be in touch about your project. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.
