### PR TITLE
Add project 1Password aarch64

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -337,5 +337,14 @@
 		"url": "https://github.com/guilhermedea/inserindo-segredos-com-o-1Password",
 		"description": "Guia básico em Português de como inserir segredos no código utilizando o 1Password",
 		"tags": ["automation", "cli", "visual studio code", "secret reference"]
+	},
+    {
+		"category": "repo",
+		"id": "beeemT-1Password-aarch64",
+		"title": "1Password AARCH64",
+		"author": "beeemT",
+		"url": "https://github.com/beeemT/1Password-aarch64",
+		"description": "1Password for Linux Apple Silicon",
+		"tags": ["1Password", "AARCH64", "ARM64", "Apple Silicon"]
 	}
 ]


### PR DESCRIPTION

## 1Password-AARCH64

#### 1Password PKGBUILD for ARM64

This project takes the existing AUR package of 1Password and adjusts the PKGBUILD such that it runs on Apple Silicon

#### Project category

- [x] Repository
- [ ] Article
- [ ] Video

#### Developer Tools used

- [ ] CLI
- [ ] Connect Server
- [ ] CI/CD Integrations
- [ ] SSH Agent
- [ ] Events Reporting API
- [ ] Passage or passwordless
- [x] Something else... 
1Password itself

#### URL

https://github.com/beeemT/1Password-aarch64

#### Author

Benedikt Thoma [LinkedIn](https://linkedin.com/in/benedikt-thoma

#### Can we contact you?

We'd love to be in touch about your project. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.
