### PR TITLE
Add secrets-store-csi-driver

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -337,5 +337,14 @@
 		"url": "https://github.com/guilhermedea/inserindo-segredos-com-o-1Password",
 		"description": "Guia básico em Português de como inserir segredos no código utilizando o 1Password",
 		"tags": ["automation", "cli", "visual studio code", "secret reference"]
+	},
+	{
+		"category": "repo",
+		"id": "secrets-store-csi-driver-provider-1password",
+		"title": "1Password Provider for Secret Store CSI Driver",
+		"author": "meisterlabs",
+		"url": "https://github.com/MeisterLabs/secrets-store-csi-driver-provider-1password",
+		"description": "Driver for retreiving 1password secrets using the secrets-store-csi interface for kubernetes, allowing mounting of 1password secrets in kubernetes pods",
+		"tags": ["automation", "connect", "kubernetes", "go"]
 	}
 ]


### PR DESCRIPTION
<!-- Please complete this PR template along with your updated project.json submission. -->

## Project name

1Password Provider for Secret Store CSI Driver

#### Short description

Driver for retreiving 1password secrets using the [secrets-store-csi interface](https://github.com/kubernetes-sigs/secrets-store-csi-driver) for kubernetes, allowing mounting of 1password secrets in kubernetes pods

#### Project category

- [x] Repository
- [ ] Article
- [ ] Video

#### Developer Tools used

- [ ] CLI
- [x] Connect Server
- [ ] CI/CD Integrations
- [ ] SSH Agent
- [ ] Events Reporting API
- [ ] Passage or passwordless
- [x] Something else... <!-- Please describe below -->

#### URL

https://github.com/MeisterLabs/secrets-store-csi-driver-provider-1password

#### Author

[MeisterLabs](https://meisterlabs.com)

#### Can we contact you?

We'd love to be in touch about your project. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.  I'm on the 1password community slack as `@Martyn Ranyard`.  [Original thread there](https://1password-devs.slack.com/archives/C04NP76M709/p1683135643193279).
