### PR TITLE
Add `joão` configuration manager

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -347,7 +347,7 @@
 		"description": "Access 1Password from Golang code - no Connect server required",
 		"tags": ["sdk", "go", "library", "cli"]
 	},
-  {
+  	{
 		"category": "repo",
 		"id": "secrets-store-csi-driver-provider-1password",
 		"title": "1Password Provider for Secret Store CSI Driver",
@@ -355,5 +355,14 @@
 		"url": "https://github.com/MeisterLabs/secrets-store-csi-driver-provider-1password",
 		"description": "Driver for retreiving 1password secrets using the secrets-store-csi interface for kubernetes, allowing mounting of 1password secrets in kubernetes pods",
 		"tags": ["automation", "connect", "kubernetes", "go"]
-  }
+  	},
+  	{
+		"category": "repo",
+		"id": "mx-rob-git-nidito-joao",
+		"title": "joão",
+		"author": "Roberto Hidalgo",
+		"url": "https://github.com/unRob/joao",
+		"description": "A command-line configuration manager that keeps entries encoded as YAML in the filesystem, backed up to 1Password; syncs scrubbed copies to git and robots consume entries via 1Password Connect + Vault. ",
+		"tags": ["automation", "cli", "connect", "hashicorp", "vault", "go"]
+  	}
 ]

--- a/projects.json
+++ b/projects.json
@@ -347,7 +347,7 @@
 		"description": "Access 1Password from Golang code - no Connect server required",
 		"tags": ["sdk", "go", "library", "cli"]
 	},
-  	{
+	{
 		"category": "repo",
 		"id": "secrets-store-csi-driver-provider-1password",
 		"title": "1Password Provider for Secret Store CSI Driver",
@@ -355,8 +355,8 @@
 		"url": "https://github.com/MeisterLabs/secrets-store-csi-driver-provider-1password",
 		"description": "Driver for retreiving 1password secrets using the secrets-store-csi interface for kubernetes, allowing mounting of 1password secrets in kubernetes pods",
 		"tags": ["automation", "connect", "kubernetes", "go"]
-  	},
-  	{
+	},
+	{
 		"category": "repo",
 		"id": "mx-rob-git-nidito-joao",
 		"title": "joão",
@@ -364,5 +364,5 @@
 		"url": "https://github.com/unRob/joao",
 		"description": "A command-line configuration manager that keeps entries encoded as YAML in the filesystem, backed up to 1Password; syncs scrubbed copies to git and robots consume entries via 1Password Connect + Vault.",
 		"tags": ["automation", "cli", "connect", "hashicorp", "vault", "go"]
-  	}
+	}
 ]

--- a/projects.json
+++ b/projects.json
@@ -362,7 +362,7 @@
 		"title": "joão",
 		"author": "Roberto Hidalgo",
 		"url": "https://github.com/unRob/joao",
-		"description": "A command-line configuration manager that keeps entries encoded as YAML in the filesystem, backed up to 1Password; syncs scrubbed copies to git and robots consume entries via 1Password Connect + Vault. ",
+		"description": "A command-line configuration manager that keeps entries encoded as YAML in the filesystem, backed up to 1Password; syncs scrubbed copies to git and robots consume entries via 1Password Connect + Vault.",
 		"tags": ["automation", "cli", "connect", "hashicorp", "vault", "go"]
   	}
 ]


### PR DESCRIPTION
## Project name

`joão`

#### Short description

A command-line configuration manager that keeps entries encoded as YAML in the filesystem, backed up to 1Password; syncs scrubbed copies to git and robots consume entries via 1Password Connect + Vault.


#### Project category

- [x] Repository
- [ ] Article
- [ ] Video

#### Developer Tools used

- [x] CLI
- [x] Connect Server
- [ ] CI/CD Integrations
- [ ] SSH Agent
- [ ] Events Reporting API
- [ ] Passage or passwordless
- [ ] Something else... <!-- Please describe below -->

#### URL

https://github.com/unRob/joao

#### Author

Roberto Hidalgo https://club.pati.to/@rob

#### Can we contact you?

We'd love to be in touch about your project. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.
