### PR TITLE
Add `SDKs` as an option in the PR template for adding a developer project 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,7 @@
 - [ ] SSH Agent
 - [ ] Events Reporting API
 - [ ] Passage or passwordless
+- [ ] SDKs
 - [ ] Something else... <!-- Please describe below -->
 
 #### URL


### PR DESCRIPTION
Adding the SDKs as an option in the README template, within the Developer Tools that can be used to build integrations.