### PR TITLE
Add op-orm to projects.json

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1,5 +1,15 @@
 [
 	{
+		"category": "repo",
+		"id": "object-relational-manager-for-1password",
+		"title": "A ORM implementation for 1Password",
+		"author": "ilke-dev",
+		"url": "https://github.com/Ilke-dev/op-orm",
+		"description": "A Object Relational Manager (ORM) wrapper around the onepassword-sdk-python",
+		"createdAt": "2025-02-18",
+		"tags": ["python", "sdk", "orm", "cli", "devops", "automation", "kubernetes", "k8s"]
+	},
+	{
 		"category": "article",
 		"id": "sickle-1password-meets-git",
 		"title": "1Password Meets Git",


### PR DESCRIPTION
## Project name
op-orm

#### Short description

I've create a ORM wrapper around the onepassword-sdk-python library. With op-orm you can express your 1password items in code and also generate kubernetes secret deployments with the secret references for the 1password kubernetes operator (connect server). This way you can use the tool in CI/CD pipelines, perform password rotations and manage 1password vaults. 

#### Project category

- [x] Repository
- [ ] Article
- [ ] Video

#### Developer Tools used

- [ ] CLI
- [x] Connect Server
- [ ] CI/CD Integrations
- [ ] SSH Agent
- [ ] Events Reporting API
- [ ] Passage or passwordless
- [x] SDKs
- [ ] Something else... <!-- Please describe below -->

#### URL

https://github.com/Ilke-dev/op-orm

#### Author
Name: Ilke 
Email: github@ilke.dev

#### Can we contact you?

We'd love to be in touch about your project. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.
