### PR TITLE
Check signed commits

### DIFF
--- a/.github/workflows/check-signed-commits.yml
+++ b/.github/workflows/check-signed-commits.yml
@@ -1,0 +1,13 @@
+name: Check signed commits in PR
+on: pull_request_target
+
+jobs:
+  build:
+    name: Check signed commits in PR
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check signed commits in PR
+        uses: 1Password/check-signed-commits-action@main


### PR DESCRIPTION
This action immediately leaves a message on the pull request letting the author know they need to sign their commits, and explains how they can do so.

This enables authors to tackle commit signing while they're still in the flow of the contribution, and prevents pull requests going stale as seen in
https://github.com/1Password/developer-community-projects/pull/19