### PR TITLE
feat: add oprun.sh to projects.json

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -405,5 +405,15 @@
 		"description": "An integration for using 1Password as a secret backend with vals",
 		"createdAt": "2024-06-04",
 		"tags": ["vals", "1password sdks", "secret reference", "service accounts"]
+	},
+	{
+		"category": "repo",
+		"id": "mykalmachon-op-run-wsl",
+		"title": "oprun.sh",
+		"author": "Mykal Machon (mykalmachon)",
+		"url": "https://github.com/MykalMachon/oprun.sh",
+		"description": "The 1Password CLI's `op run` utility re-implemented as a bash script using `op inject` to add Windows Subsystem for Linux support.",
+		"createdAt": "2025-07-30",
+		"tags": ["cli", "windows", "wsl"]
 	}
 ]


### PR DESCRIPTION
adding oprun.sh information to projects.json

## `oprun.sh`

#### Short description

I use Windows Subsystem for Linux (WSL) for development and rely on 1Password to manage secrets for production, staging, and local workflows. My organization requires SSO authentication for 1Password, which means I must use the Windows 1Password CLI from within WSL to access my work credentials.

**While most 1Password CLI features work in WSL through Windows interoperability, op run fails because it always executes commands in a Windows context, even when called from within WSL.**

With that in mind, I created oprun.sh to emulate the ergonomics and utility of `op run` using `op inject` to achieve that under the hood.

#### Project category

- [x] Repository
- [ ] Article
- [ ] Video

#### Developer Tools used

- [x] CLI
- [ ] Connect Server
- [ ] CI/CD Integrations
- [ ] SSH Agent
- [ ] Events Reporting API
- [ ] Passage or passwordless
- [ ] SDKs
- [ ] Something else... <!-- Please describe below -->

#### URL

Here's [a link to the GitHub Repo MykalMachon/oprun.sh](https://github.com/MykalMachon/oprun.sh)

#### Author

- Mykal Machon: [send me an email](mailto:mykal@tinybox.dev)

#### Can we contact you?

We'd love to be in touch about your project. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.
